### PR TITLE
add Wechaty Plugin Developers to the Voteout room config

### DIFF
--- a/src/plugins/vote-out.ts
+++ b/src/plugins/vote-out.ts
@@ -42,6 +42,7 @@ const config: VoteOutConfig = {
   room: [
     /^Wechaty Developers/i,
     /^Youth fed the/i,
+    /^Wechaty Plugin Developers/i,
   ],
   threshold: 3,
   kick,


### PR DESCRIPTION
I have add `Wechaty Plugin Developers` to the voteout room config. But I recommand that config may be:

```typescript
const config: VoteOutConfig = {
  room: [
    /^Youth fed the/i,
    /^Wechaty * Developers/i,
  ],
```
So, it can match more `Wechaty`- * - `Developers` chatrooms. Or, the name of our developer chatroom can follow this rules.