### PR TITLE
add whatsapp for Friday BOT

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "wechaty-puppet-official-account": "^1.10.3",
     "wechaty-puppet-oicq": "^1.10.2",
     "wechaty-puppet-service": "^1.11.2",
+    "wechaty-puppet-whatsapp": "^1.11.3",
     "wechaty-qnamaker": "^1.11.1",
     "wechaty-vorpal": "^1.11.4",
     "wechaty-vorpal-contrib": "^1.11.5",

--- a/src/bots/mod.ts
+++ b/src/bots/mod.ts
@@ -3,6 +3,7 @@ import { getWxWork }  from './wxwork/bot.js'
 import { getHuanOa }  from './huan-oa/bot.js'
 import { getGitter }  from './gitter/bot.js'
 import { getQQ }      from './qq/bot.js'
+import { getWhatsapp } from './whatsapp/bot.js'
 
 void getCeibs
 void getWxWork
@@ -19,6 +20,7 @@ const getBots = () => ({
   oa: getHuanOa('Huan.OA'),
   // wxwork : getWxWork('WxWork.BOT'),
   qq: getQQ('QQ'),
+  whatsapp: getWhatsapp('Whatsapp'),
 })
 
 export { getBots }

--- a/src/bots/whatsapp/bot.ts
+++ b/src/bots/whatsapp/bot.ts
@@ -1,0 +1,32 @@
+import {
+  WechatyBuilder,
+  log,
+}             from 'wechaty'
+
+import { PuppetWhatsapp }  from 'wechaty-puppet-whatsapp'
+
+import { pluginList }       from './plugins/mod.js'
+import { vorpalPluginList } from './vorpals/mod.js'
+
+function getWhatsapp (name: string) {
+  log.verbose('getWechaty', 'getWhatsapp(%s)', name)
+
+  const puppet = new PuppetWhatsapp()
+
+  const bot = WechatyBuilder.build({
+    name,
+    puppet,
+  })
+
+  void pluginList
+  void vorpalPluginList
+
+  bot.use([
+    ...pluginList,
+    ...vorpalPluginList,
+  ])
+
+  return bot
+}
+
+export { getWhatsapp }

--- a/src/bots/whatsapp/plugins/mod.ts
+++ b/src/bots/whatsapp/plugins/mod.ts
@@ -1,0 +1,20 @@
+/**
+ * Wechaty Plugin Support with KickOut Example #1939
+ *  https://github.com/wechaty/wechaty/issues/1939
+ */
+import {
+  DingDong,
+  EventLogger,
+}                    from 'wechaty-plugin-contrib'
+
+// import {
+//   QnAMakerCeibsPlugin,
+// }                           from './qnamaker.js'
+
+const pluginList = [
+  DingDong(),
+  EventLogger(),
+  // QnAMakerCeibsPlugin,
+]
+
+export { pluginList }

--- a/src/bots/whatsapp/vorpals/mod.ts
+++ b/src/bots/whatsapp/vorpals/mod.ts
@@ -1,0 +1,3 @@
+const vorpalPluginList = [] as any
+
+export { vorpalPluginList }


### PR DESCRIPTION
Thanks to the @wechaty/juzi team, we are preparing the Beta for Whatsapp Puppet for Wechaty.

- https://github.com/wechaty/puppet-whatsapp/issues/118

So we can have a `Whatsapp Developers' Home` on Whatsapp soon, with this PR.

And this PR is also a demonstrate for how to add a new Wechaty Puppet for the Friday BOT.